### PR TITLE
changes made to user dropdown

### DIFF
--- a/lms/templates/header/user_dropdown.html
+++ b/lms/templates/header/user_dropdown.html
@@ -1,0 +1,43 @@
+## mako
+<%page expression_filter="h"/>
+<%namespace name='static' file='static_content.html'/>
+
+<%!
+from urlparse import urljoin
+
+from django.conf import settings
+from django.urls import reverse
+from django.utils.translation import ugettext as _
+
+from openedx.core.djangoapps.user_api.accounts.utils import retrieve_last_sitewide_block_completed
+%>
+
+<%
+## This template should not use the target student's details when masquerading, see TNL-4895
+self.real_user = getattr(user, 'real_user', user)
+username = self.real_user.username
+resume_block = retrieve_last_sitewide_block_completed(self.real_user)
+full_name = self.real_user.get_full_name()
+dashboard_url = urljoin(settings.XPRO_BASE_URL, "dashboard")
+profile_url = urljoin(settings.XPRO_BASE_URL, "profile")
+%>
+
+<div class="nav-item hidden-mobile">
+    <a href="${reverse('dashboard')}" class="menu-title">
+        <span class="sr-only">${_("Dashboard for:")}</span>
+        <span class="username">${full_name}</span>
+    </a>
+</div>
+<div class="nav-item hidden-mobile nav-item-dropdown" tabindex="-1">
+    <div class="toggle-user-dropdown" role="button" aria-label=${_("Options Menu")} aria-expanded="false" tabindex="0" aria-controls="user-menu">
+        <span class="fa fa-caret-down" aria-hidden="true"></span>
+    </div>
+    <div class="dropdown-user-menu hidden" aria-label=${_("More Options")} role="menu" id="user-menu" tabindex="-1">
+        % if resume_block:
+            <div class="mobile-nav-item dropdown-item dropdown-nav-item"><a href="${resume_block}" role="menuitem">${_("Resume your last course")}</a></div>
+        % endif
+        <div class="mobile-nav-item dropdown-item dropdown-nav-item"><a href="${dashboard_url}" role="menuitem">${_("Dashboard")}</a></div>
+        <div class="mobile-nav-item dropdown-item dropdown-nav-item"><a href="${profile_url}" role="menuitem">${_("Profile")}</a></div>
+        <div class="mobile-nav-item dropdown-item dropdown-nav-item"><a href="${reverse('logout')}" role="menuitem">${_("Sign Out")}</a></div>
+    </div>
+</div>


### PR DESCRIPTION
Fixes https://github.com/mitodl/mitxpro/issues/582

**What this PR do?**
- [x] replace username with ~~email~~ user's full name
- [x] remove the user profile image
- [x] link dashboard to https://xpro.mit.edu/dashboard/
- [x] link profile to https://xpro.mit.edu/profile
- [x] remove account (this page doesn't exist yet on xpro)

**How this should be tested:**

- [Apply theme](https://edx.readthedocs.io/projects/edx-installing-configuring-and-running/en/latest/configuration/changing_appearance/theming/enable_themes.html), and visit dashboard.
- Set `XPRO_BASE_URL` in settings
- You should see above changes.

**Screenshot(s):**
<img width="665" alt="Screen Shot 2019-07-03 at 12 58 25 PM" src="https://user-images.githubusercontent.com/4245618/60574098-577b5f80-9d92-11e9-8e56-435eba08f3c0.png">
