### PR TITLE
#654 Remove sign in/register buttons from logout view

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -102,3 +102,7 @@ venv.bak/
 
 # mypy
 .mypy_cache/
+
+# ignore generated assets
+lms/static/css
+cms/static/css

--- a/lms/static/templates
+++ b/lms/static/templates
@@ -1,0 +1,1 @@
+../templates

--- a/lms/templates/header/navbar-not-authenticated.html
+++ b/lms/templates/header/navbar-not-authenticated.html
@@ -1,0 +1,45 @@
+## mako
+
+<%page expression_filter="h"/>
+
+<%namespace name='static' file='../static_content.html'/>
+<%namespace file='../main.html' import="login_query"/>
+
+<%!
+from django.urls import reverse
+from django.utils.translation import ugettext as _
+from six import text_type
+%>
+
+<%
+  mktg_site_enabled = static.get_value('ENABLE_MKTG_SITE', settings.FEATURES.get('ENABLE_MKTG_SITE', False))
+  courses_are_browsable = settings.FEATURES.get('COURSES_ARE_BROWSABLE')
+  allows_login = not settings.FEATURES['DISABLE_LOGIN_BUTTON'] and not combined_login_and_register
+  can_discover_courses = settings.FEATURES.get('ENABLE_COURSE_DISCOVERY')
+  restrict_enroll_for_course = course and settings.FEATURES.get('RESTRICT_ENROLL_BY_REG_METHOD') and course.enrollment_domain
+  allow_public_account_creation = static.get_value('ALLOW_PUBLIC_ACCOUNT_CREATION', settings.FEATURES.get('ALLOW_PUBLIC_ACCOUNT_CREATION'))
+%>
+<nav class="nav-links" aria-label=${_("Supplemental Links")}>
+  <div class="main">
+  % if mktg_site_enabled:
+    <div class="mobile-nav-item hidden-mobile nav-item">
+      <a href="${marketing_link('HOW_IT_WORKS')}">${_("How it Works")}</a>
+    </div>
+    % if courses_are_browsable:
+      <div class="mobile-nav-item hidden-mobile nav-item">
+        <a href="${marketing_link('COURSES')}">${_("Courses")}</a>
+      </div>
+    % endif
+    <div class="mobile-nav-item hidden-mobile nav-item">
+      <a href="${marketing_link('SCHOOLS')}">${_("Schools")}</a>
+    </div>
+  % endif
+  % if allows_login:
+    % if can_discover_courses:
+      <div class="mobile-nav-item hidden-mobile nav-item">
+        <a href="/courses">${_('Explore courses')}</a>
+      </div>
+    %endif
+  % endif
+  </div>
+</nav>


### PR DESCRIPTION
This PR removes the `Sign In` and `Register` links from the navigation bar at the top which appears for non-authenticated users. This impacts the intermediate logout view from OpenEdX to xPRO redirection where previously these buttons were visible while OpenEdX was redirecting the user to xPRO after a logout.

Screenshot:
![Screenshot from 2019-07-12 14-40-31](https://user-images.githubusercontent.com/45350418/61119375-1e3ea000-a4b4-11e9-8abf-3f2c58f90eef.png)
