### PR TITLE
update 404 page

### DIFF
--- a/cms/templates/404.html
+++ b/cms/templates/404.html
@@ -17,10 +17,10 @@ from openedx.core.djangolib.markup import HTML, Text
     <article class="content-primary" role="main">
       <p>
       ${_('The page that you were looking for was not found.')}
-      ${Text(_('Go back to the {homepage} or contact us about any pages that may have been moved at {email}.')).format(
+      ${Text(_('Go back to the {homepage} or contact us about any pages that may have been moved at {contact_us}.')).format(
         homepage=HTML('<a href="{xpro_base_url}">homepage</a>').format(xpro_base_url=settings.XPRO_BASE_URL),
-        email=HTML('<a href="mailto:{address}">{address}</a>').format(
-          address=Text(settings.TECH_SUPPORT_EMAIL)
+        contact_us=HTML('<a href="{address}">contact us</a>').format(
+          address=Text(settings.MKTG_URLS.get('CONTACT', None))
         )
       )}
       </p>

--- a/cms/templates/404.html
+++ b/cms/templates/404.html
@@ -1,0 +1,30 @@
+<%page expression_filter="h"/>
+<%!
+from django.utils.translation import ugettext as _
+from openedx.core.djangolib.markup import HTML, Text
+%>
+<%inherit file="base.html" />
+<%block name="title">${_("Page Not Found")}</%block>
+<%block name="bodyclass">view-util util-404</%block>
+
+
+<%block name="content">
+<div class="wrapper-content wrapper">
+  <section class="content">
+    <header>
+      <h1 class="title title-1">${_("Page not found")}</h1>
+    </header>
+    <article class="content-primary" role="main">
+      <p>
+      ${_('The page that you were looking for was not found.')}
+      ${Text(_('Go back to the {homepage} or contact us about any pages that may have been moved at {email}.')).format(
+        homepage=HTML('<a href="{xpro_base_url}">homepage</a>').format(xpro_base_url=settings.XPRO_BASE_URL),
+        email=HTML('<a href="mailto:{address}">{address}</a>').format(
+          address=Text(settings.TECH_SUPPORT_EMAIL)
+        )
+      )}
+      </p>
+    </article>
+  </section>
+</div>
+</%block>

--- a/lms/templates/static_templates/404.html
+++ b/lms/templates/static_templates/404.html
@@ -21,8 +21,8 @@ from openedx.core.djangolib.markup import HTML, Text
                 ${_('The page that you were looking for was not found.')}
                 ${Text(_('Go back to the {homepage} or contact us about any pages that may have been moved at {email}.')).format(
                   homepage=HTML('<a href="{xpro_base_url}">homepage</a>').format(xpro_base_url=settings.XPRO_BASE_URL),
-                  email=HTML('<a href="mailto:{address}">{address}</a>').format(
-                    address=Text(settings.TECH_SUPPORT_EMAIL)
+                  email=HTML('<a href="{address}">contact us</a>').format(
+                    address=Text(settings.MKTG_URLS.get('CONTACT', None))
                   )
                 )}
                 % endif

--- a/lms/templates/static_templates/404.html
+++ b/lms/templates/static_templates/404.html
@@ -1,0 +1,32 @@
+<%page expression_filter="h"/>
+<%namespace name='static' file='../static_content.html'/>
+<%!
+from django.utils.translation import ugettext as _
+from openedx.core.djangolib.markup import HTML, Text
+%>
+<%inherit file="../main.html" />
+
+<%block name="pagetitle">${_("Page Not Found")}</%block>
+
+<main id="main" aria-label="Content" tabindex="-1">
+    <section class="outside-app">
+        <h1>
+            <%block name="pageheader">${page_header or _("Page not found")}</%block>
+        </h1>
+        <p>
+            <%block name="pagecontent">
+                % if page_content:
+                    ${page_content}
+                % else:
+                ${_('The page that you were looking for was not found.')}
+                ${Text(_('Go back to the {homepage} or contact us about any pages that may have been moved at {email}.')).format(
+                  homepage=HTML('<a href="{xpro_base_url}">homepage</a>').format(xpro_base_url=settings.XPRO_BASE_URL),
+                  email=HTML('<a href="mailto:{address}">{address}</a>').format(
+                    address=Text(settings.TECH_SUPPORT_EMAIL)
+                  )
+                )}
+                % endif
+            </%block>
+        </p>
+    </section>
+</main>


### PR DESCRIPTION
**Relevant tickets:**
Fixes https://github.com/mitodl/mitxpro/issues/819

**What this PR do?**
Update 404 pages in CMS and LMS

**How to test it manually?**

- Make sure you have `XPRO_BASE_URL="http://xpro.odl.local:8053/"` and `TECH_SUPPORT_EMAIL="MIT xPRO <xpro@mit.edu>"` in settings
- Visit any page which doesn't exists. :)

**Screenshot:**
**LMS**
<img width="872" alt="Screen Shot 2019-07-17 at 1 21 43 PM" src="https://user-images.githubusercontent.com/4245618/61359532-eb225500-a895-11e9-91f2-9d1bee201d09.png">
