### PR TITLE
#820 OpenEdx Theme Footer Links

### DIFF
--- a/lms/templates/footer.html
+++ b/lms/templates/footer.html
@@ -1,12 +1,31 @@
 ## mako
 <%page expression_filter="h"/>
 <%!
+  from urlparse import urljoin
   from django.urls import reverse
   from django.utils.translation import ugettext as _
   from branding.api import get_footer
   from openedx.core.djangoapps.lang_pref.api import footer_language_selector_is_enabled
+  from openedx.core.djangoapps.site_configuration import helpers as configuration_helpers
 %>
-<% footer = get_footer(is_secure=is_secure) %>
+<%
+  platform_name = configuration_helpers.get_value('platform_name', settings.PLATFORM_NAME)
+  footer = get_footer(is_secure=is_secure)
+  footer['copyright'] = _(u"\u00A9 {org_name}.  All rights reserved except where noted.").format(org_name=platform_name)
+  footer['navigation_links'] = [
+    {
+        "name": link_name,
+        "title": link_title,
+        "url": link_url,
+    }
+    for link_name, link_url, link_title in [
+        ("about", urljoin(settings.XPRO_BASE_URL, '/about-us/'), _("About")),
+        ("help-center", "https://xpro.zendesk.com/hc/", _("Support Center")),
+        ("contact", "https://xpro.zendesk.com/hc/en-us/requests/new", _("Contact")),
+    ]
+    if link_url and link_url != "#"
+  ]
+%>
 <%namespace name='static' file='static_content.html'/>
 
 % if uses_bootstrap:

--- a/lms/templates/footer.html
+++ b/lms/templates/footer.html
@@ -2,8 +2,10 @@
 <%page expression_filter="h"/>
 <%!
   from urlparse import urljoin
+  from django.conf import settings
   from django.urls import reverse
   from django.utils.translation import ugettext as _
+  from edxmako.shortcuts import marketing_link
   from branding.api import get_footer
   from openedx.core.djangoapps.lang_pref.api import footer_language_selector_is_enabled
   from openedx.core.djangoapps.site_configuration import helpers as configuration_helpers
@@ -12,19 +14,16 @@
   platform_name = configuration_helpers.get_value('platform_name', settings.PLATFORM_NAME)
   footer = get_footer(is_secure=is_secure)
   footer['copyright'] = _(u"\u00A9 {org_name}.  All rights reserved except where noted.").format(org_name=platform_name)
-  footer['navigation_links'] = [
-    {
-        "name": link_name,
-        "title": link_title,
-        "url": link_url,
-    }
-    for link_name, link_url, link_title in [
-        ("about", urljoin(settings.XPRO_BASE_URL, '/about-us/'), _("About")),
-        ("help-center", "https://xpro.zendesk.com/hc/", _("Support Center")),
-        ("contact", "https://xpro.zendesk.com/hc/en-us/requests/new", _("Contact")),
-    ]
-    if link_url and link_url != "#"
-  ]
+  for idx, link_data in enumerate(footer["navigation_links"]):
+    if link_data["name"] == "help-center":
+      link_data["title"] = _("Support Center")
+      footer["navigation_links"][idx] = link_data
+    elif link_data["name"] == "contact":
+      contact_url = settings.MKTG_URLS.get("CONTACT", None)
+      if contact_url:
+        link_data["url"] = contact_url
+        footer["navigation_links"][idx] = link_data
+
 %>
 <%namespace name='static' file='static_content.html'/>
 


### PR DESCRIPTION
Updates footer links in template in accordance to https://github.com/mitodl/mitxpro/issues/820

#### Devops/Testing requirements
- `ENABLE_MKTG_SITE` should be set to `True`
- `SUPPORT_SITE_LINK` should be set to `https://xpro.zendesk.com/hc/`
- `CONTACT` (inside `MKTG_URLS`) should have the absolute URL: `https://xpro.zendesk.com/hc/en-us/requests/new`
- `BLOG`, `ENTERPRISE`, `DONATE` etc. (keys for links that we don't want) should not exist in `MKTG_URLS`


Screenshot
![Screenshot from 2019-07-16 13-26-27](https://user-images.githubusercontent.com/45350418/61278355-7c79c480-a7cd-11e9-90a6-8451396ab050.png)
