### PR TITLE
display user's full name in studio header

### DIFF
--- a/cms/templates/widgets/user_dropdown.html
+++ b/cms/templates/widgets/user_dropdown.html
@@ -1,0 +1,65 @@
+<%page expression_filter="h"/>
+<%namespace name='static' file='../static_content.html'/>
+<%!
+  from django.conf import settings
+  from django.urls import reverse
+  from django.utils.translation import ugettext as _
+  from student.roles import GlobalStaff
+  from student.models import UserProfile
+
+%>
+
+<%
+full_name = UserProfile.objects.get(user=user).name
+%>
+
+% if uses_pattern_library:
+  <div class="wrapper-user-menu dropdown-menu-container logged-in js-header-user-menu">
+      <h3 class="title menu-title">
+          <span class="sr-only">${_("Currently signed in as:")}</span>
+          <span class="account-username" title="${ full_name }">${ full_name }</span>
+      </h3>
+      <button type="button" class="menu-button button-more has-dropdown js-dropdown-button" aria-haspopup="true" aria-expanded="false" aria-controls="${_("Usermenu")}">
+          <span class="icon-fallback icon-fallback-img">
+            <span class="icon icon-angle-down" aria-hidden="true"></span>
+            <span class="sr-only">${_("Usermenu dropdown")}</span>
+          </span>
+      </button>
+      <ul class="dropdown-menu list-divided is-hidden" id="${_("Usermenu")}" tabindex="-1">
+          <%block name="navigation_dropdown_menu_links" >
+              <li class="dropdown-item item has-block-link">
+                <a href="/">${_("{studio_name} Home").format(studio_name=settings.STUDIO_SHORT_NAME)}</a>
+              </li>
+          </%block>
+          <li class="dropdown-item item has-block-link">
+            <a class="action action-signout" href="${reverse('logout')}">${_("Sign Out")}</a>
+          </li>
+      </ul>
+  </div>
+
+% else:
+  <h3 class="title">
+    <span class="label">
+      <span class="label-prefix sr-only">${_("Currently signed in as:")}</span>
+      <span class="account-username" title="${ full_name }">${ full_name }</span>
+    </span>
+    <span class="icon fa fa-caret-down ui-toggle-dd" aria-hidden="true"></span>
+  </h3>
+  <div class="wrapper wrapper-nav-sub">
+    <div class="nav-sub">
+      <ul>
+        <li class="nav-item nav-account-dashboard">
+          <a href="/">${_("{studio_name} Home").format(studio_name=settings.STUDIO_SHORT_NAME)}</a>
+        </li>
+        % if GlobalStaff().has_user(user):
+        <li class="nav-item">
+          <a href="${reverse('maintenance:maintenance_index')}">${_("Maintenance")}</a>
+        </li>
+        % endif
+        <li class="nav-item nav-account-signout">
+          <a class="action action-signout" href="${settings.FRONTEND_LOGOUT_URL}">${_("Sign Out")}</a>
+        </li>
+      </ul>
+    </div>
+  </div>
+% endif


### PR DESCRIPTION
**Relevant ticket:**
Fixes https://github.com/mitodl/mitxpro/issues/942

**What this PR do?**
Override `cms/templates/widgets/user_dropdown.html` to show user's full name in studio header.

**How to test it manually?**

- Make sure you have `name` set against your user.
- Visit studio, you should see full name in header.

**Screenshot(if applicable)**
![Screenshot 2019-08-07 at 4 01 50 PM](https://user-images.githubusercontent.com/4245618/62618320-61622680-b92d-11e9-9353-7c2d97de7572.png)
