### PR TITLE
replace discover new with catalog and link it to xPRO catalog

### DIFF
--- a/lms/templates/header/navbar-authenticated.html
+++ b/lms/templates/header/navbar-authenticated.html
@@ -1,0 +1,92 @@
+## mako
+
+<%page expression_filter="h" args="online_help_token"/>
+
+<%namespace name='static' file='../static_content.html'/>
+<%namespace file='../main.html' import="login_query"/>
+<%!
+from urlparse import urljoin
+
+from django.urls import reverse
+from django.utils.translation import ugettext as _
+from openedx.core.djangoapps.site_configuration import helpers as configuration_helpers
+%>
+
+<%
+  show_explore_courses = settings.FEATURES.get('COURSES_ARE_BROWSABLE') and not show_program_listing
+  show_sysadmin_dashboard = settings.FEATURES.get('ENABLE_SYSADMIN_DASHBOARD','') and user.is_staff
+  self.real_user = getattr(user, 'real_user', user)
+
+  support_link = configuration_helpers.get_value('SUPPORT_SITE_LINK', settings.SUPPORT_SITE_LINK)
+  doc_link = get_online_help_info(online_help_token)['doc_url']
+  catalog_link = urljoin(settings.XPRO_BASE_URL, "catalog")
+
+  if online_help_token == "instructor":
+    help_link = doc_link
+  elif support_link:
+    help_link = support_link
+  else:
+    help_link = doc_link
+%>
+
+<div class="nav-links">
+  <div class="main">
+    % if show_dashboard_tabs:
+      <div class="mobile-nav-item hidden-mobile nav-item nav-tab">
+        <a class="${'active ' if reverse('dashboard') == request.path else ''}tab-nav-link" href="${reverse('dashboard')}"
+             aria-current="${'page' if reverse('dashboard') == request.path else 'false'}">
+             ${_("Courses")}
+        </a>
+      </div>
+      % if show_program_listing:
+        <div class="mobile-nav-item hidden-mobile nav-item nav-tab">
+          <a class="${'active ' if reverse('program_listing_view') in request.path else ''}tab-nav-link" href="${reverse('program_listing_view')}"
+             aria-current="${'page' if reverse('program_listing_view') == request.path else 'false'}">
+             ${_("Programs")}
+          </a>
+        </div>
+      % endif
+      % if show_journal_listing:
+        <div class="mobile-nav-item hidden-mobile nav-item nav-tab">
+          <a class="${'active ' if reverse('openedx.journals.dashboard') in request.path else ''}tab-nav-link" href="${reverse('openedx.journals.dashboard')}"
+             aria-current="${'page' if reverse('openedx.journals.dashboard') == request.path else 'false'}">
+             ${_("Journals")}
+          </a>
+        </div>
+      % endif
+      <div class="mobile-nav-item hidden-mobile nav-item nav-tab">
+          <a class="${'active ' if '/u/' in request.path  else ''}tab-nav-link" href="${reverse('learner_profile', args=[self.real_user.username])}"
+             aria-current="${'page' if '/u/' in request.path else 'false'}">
+             ${_("Profile")}
+          </a>
+      </div>
+    % endif
+    % if show_explore_courses:
+      <div class="mobile-nav-item hidden-mobile nav-item nav-tab">
+          <a class="tab-nav-link" href="${catalog_link}"
+             aria-current="${'page' if '/courses' in request.path else 'false'}">
+             ${_('Catalog')}
+          </a>
+      </div>
+    % endif
+    % if show_sysadmin_dashboard:
+      <div class="mobile-nav-item hidden-mobile nav-item nav-tab">
+        ## Translators: This is short for "System administration".
+        <a class="tab-nav-link" href="${reverse('sysadmin')}">${_("Sysadmin")}</a>
+      </div>
+    % endif
+  </div>
+  <div class="secondary">
+    % if should_display_shopping_cart_func() and not (course and static.is_request_in_themed_site()): # see shoppingcart.context_processor.user_has_cart_context_processor
+      <div class="mobile-nav-item hidden-mobile nav-item">
+        <a class="shopping-cart" href="${reverse('shoppingcart.views.show_cart')}">
+          <span class="icon fa fa-shopping-cart" aria-hidden="true"></span> ${_("Shopping Cart")}
+        </a>
+      </div>
+    % endif
+    <div class="mobile-nav-item hidden-mobile nav-item">
+      <a class="help-link" href="${help_link}" target="_blank">${_("Help")}</a>
+    </div>
+    <%include file="user_dropdown.html"/>
+  </div>
+</div>


### PR DESCRIPTION
**Relevant tickets:**
Fixes https://github.com/mitodl/mitxpro/issues/941

**What this PR do?**
override template to replace discover new with catalog and link it to xPROro catalog

**How to test it manually?**
Visit any course page on LMS, you should see catalog with link to xPro catalog.

**Screenshot(if applicable)**
<img width="1234" alt="Screenshot 2019-08-09 at 11 58 58 AM" src="https://user-images.githubusercontent.com/4245618/62760837-727e7500-ba9e-11e9-80ed-0fba2a4e054c.png">
