### PR TITLE
Changed to urllib.parse for python3

### DIFF
--- a/lms/templates/dashboard.html
+++ b/lms/templates/dashboard.html
@@ -4,7 +4,7 @@
 <%namespace name='static' file='static_content.html'/>
 <%!
 import pytz
-from urlparse import urljoin
+from urllib.parse import urljoin
 from datetime import datetime, timedelta
 from django.urls import reverse
 from django.utils.translation import ugettext as _

--- a/lms/templates/footer.html
+++ b/lms/templates/footer.html
@@ -1,7 +1,7 @@
 ## mako
 <%page expression_filter="h"/>
 <%!
-  from urlparse import urljoin
+  from urllib.parse import urljoin
   from django.conf import settings
   from django.urls import reverse
   from django.utils.translation import ugettext as _

--- a/lms/templates/header/navbar-authenticated.html
+++ b/lms/templates/header/navbar-authenticated.html
@@ -5,7 +5,7 @@
 <%namespace name='static' file='../static_content.html'/>
 <%namespace file='../main.html' import="login_query"/>
 <%!
-from urlparse import urljoin
+from urllib.parse import urljoin
 
 from django.urls import reverse
 from django.utils.translation import ugettext as _

--- a/lms/templates/header/user_dropdown.html
+++ b/lms/templates/header/user_dropdown.html
@@ -3,7 +3,7 @@
 <%namespace name='static' file='static_content.html'/>
 
 <%!
-from urlparse import urljoin
+from urllib.parse import urljoin
 
 from django.conf import settings
 from django.urls import reverse


### PR DESCRIPTION
The urlparse in Python 2.7 was renamed to urllib.parse in Python 3. This PR addresses that change