### PR TITLE
Fix footer logo to use https

### DIFF
--- a/lms/templates/footer.html
+++ b/lms/templates/footer.html
@@ -12,7 +12,7 @@
 %>
 <%
   platform_name = configuration_helpers.get_value('platform_name', settings.PLATFORM_NAME)
-  footer = get_footer(is_secure=is_secure)
+  footer = get_footer(is_secure=True)
   footer['copyright'] = _(u"\u00A9 {org_name}.  All rights reserved except where noted.").format(org_name=platform_name)
   for idx, link_data in enumerate(footer["navigation_links"]):
     if link_data["name"] == "help-center":


### PR DESCRIPTION
With juniper when logging in to the xpro sandbox, I was coming across the browser warning below:

<img width="713" alt="Screen Shot 2020-09-24 at 11 59 04 AM" src="https://user-images.githubusercontent.com/1447295/94171033-c2fd9100-fe5e-11ea-9be8-fee0ee383f96.png">

After looking around and testing manually on the sandbox, it appeared that when loading the logo in the footer, it was hitting the `else` condition over [here](https://github.com/edx/edx-platform/blob/open-release/juniper.master/lms/djangoapps/branding/api.py#L497). I tested the change in this PR manually on the sandbox, and it appeared to solve the issue.

<img width="632" alt="Screen Shot 2020-09-24 at 12 12 12 PM" src="https://user-images.githubusercontent.com/1447295/94171387-34d5da80-fe5f-11ea-8730-501fefe0f31e.png">
