### PR TITLE
Removed shopping cart reference from header

### DIFF
--- a/lms/templates/header/navbar-authenticated.html
+++ b/lms/templates/header/navbar-authenticated.html
@@ -77,13 +77,6 @@ from openedx.core.djangoapps.site_configuration import helpers as configuration_
     % endif
   </div>
   <div class="secondary">
-    % if should_display_shopping_cart_func() and not (course and static.is_request_in_themed_site()): # see shoppingcart.context_processor.user_has_cart_context_processor
-      <div class="mobile-nav-item hidden-mobile nav-item">
-        <a class="shopping-cart" href="${reverse('shoppingcart.views.show_cart')}">
-          <span class="icon fa fa-shopping-cart" aria-hidden="true"></span> ${_("Shopping Cart")}
-        </a>
-      </div>
-    % endif
     <div class="mobile-nav-item hidden-mobile nav-item">
       <a class="help-link" href="${help_link}" target="_blank">${_("Help")}</a>
     </div>


### PR DESCRIPTION
#### What are the relevant tickets?
fixes: #27 

#### What's this PR do?
Shoppingcart has been almost deprecated for quite some time so it make sense to remove the shopping cart reference from this theme repo.

#### How should this be manually tested?
Installed the mitxpro-theme repo with edx-platform master and open any course.

further reference: https://github.com/edx/edx-platform/pull/23970