### PR TITLE
rebasing dashboard with edx koa

### DIFF
--- a/lms/templates/dashboard.html
+++ b/lms/templates/dashboard.html
@@ -4,6 +4,7 @@
 <%namespace name='static' file='static_content.html'/>
 <%!
 import pytz
+import six
 from urllib.parse import urljoin
 from datetime import datetime, timedelta
 from django.urls import reverse
@@ -100,6 +101,13 @@ from student.models import CourseEnrollment
         banner.showMessage(${recovery_email_activation_message | n, dump_js_escaped_json})
       </%static:require_module>
   % endif
+  % if enterprise_learner_portal_enabled_message:
+      <%static:require_module module_name="js/views/message_banner" class_name="MessageBannerView">
+        var banner = new MessageBannerView({urgency: 'low', type: 'warning', isLearnerPortalEnabled: true});
+        $('#content').prepend(banner.$el);
+        banner.showMessage(${enterprise_learner_portal_enabled_message | n, dump_js_escaped_json})
+      </%static:require_module>
+  % endif
 </%block>
 
 <div class="dashboard-notifications" tabindex="-1">
@@ -184,7 +192,10 @@ from student.models import CourseEnrollment
                     pseudo_session = unfulfilled_entitlement_pseudo_sessions[str(entitlement.uuid)]
                     if not pseudo_session:
                         continue
-                    enrollment = CourseEnrollment(user=user, course_id=pseudo_session['key'], mode=pseudo_session['type'])
+                    pseudo_key = pseudo_session['key']
+                    if not isinstance(pseudo_key, CourseKey):
+                      pseudo_key = CourseKey.from_string(pseudo_session['key'])
+                    enrollment = CourseEnrollment(user=user, course=CourseOverview.get_from_id(pseudo_key), mode=pseudo_session['type'])
                   # We only show email settings for entitlement cards if the entitlement has an associated enrollment
                   show_email_settings = is_fulfilled_entitlement and (entitlement_session.course_id in show_email_settings_for)
                 else:
@@ -194,21 +205,27 @@ from student.models import CourseEnrollment
                 show_courseware_link = show_courseware_links_for.get(session_id, False)
                 cert_status = cert_statuses.get(session_id)
                 can_refund_entitlement = entitlement and entitlement.is_entitlement_refundable()
-                can_unenroll = (not cert_status) or cert_status.get('can_unenroll') if not unfulfilled_entitlement else False
+                partner_managed_enrollment = enrollment.mode == 'masters'
+                can_unenroll = False if partner_managed_enrollment else (not cert_status) or cert_status.get('can_unenroll') if not unfulfilled_entitlement else False
                 credit_status = credit_statuses.get(session_id)
                 course_mode_info = all_course_modes.get(session_id)
                 is_paid_course = True if entitlement else (session_id in enrolled_courses_either_paid)
-                is_course_blocked = (session_id in block_courses) if block_courses else (False)
                 course_verification_status = verification_status_by_course.get(session_id, {})
                 course_requirements = courses_requirements_not_met.get(session_id)
-                related_programs = inverted_programs.get(unicode(entitlement.course_uuid if entitlement.course_uuid and is_unfulfilled_entitlement else session_id)) if inverted_programs else []
+                related_programs = inverted_programs.get(six.text_type(entitlement.course_uuid if is_unfulfilled_entitlement else session_id))
                 show_consent_link = (session_id in consent_required_courses)
                 course_overview = enrollment.course_overview
                 resume_button_url = resume_button_urls[dashboard_index]
               %>
-              <%include file='dashboard/_dashboard_course_listing.html' args='course_overview=course_overview, course_card_index=dashboard_index, enrollment=enrollment, is_unfulfilled_entitlement=is_unfulfilled_entitlement, is_fulfilled_entitlement=is_fulfilled_entitlement, entitlement=entitlement, entitlement_session=entitlement_session, entitlement_available_sessions=entitlement_available_sessions, entitlement_expiration_date=entitlement_expiration_date, entitlement_expired_at=entitlement_expired_at, show_courseware_link=show_courseware_link, cert_status=cert_status, can_refund_entitlement=can_refund_entitlement, can_unenroll=can_unenroll, credit_status=credit_status, show_email_settings=show_email_settings, course_mode_info=course_mode_info, is_paid_course=is_paid_course, is_course_blocked=is_course_blocked, verification_status=course_verification_status, course_requirements=course_requirements, dashboard_index=dashboard_index, share_settings=share_settings, user=user, related_programs=related_programs, display_course_modes_on_dashboard=display_course_modes_on_dashboard, show_consent_link=show_consent_link, enterprise_customer_name=enterprise_customer_name, resume_button_url=resume_button_url' />
+              <%include file='dashboard/_dashboard_course_listing.html' args='course_overview=course_overview, course_card_index=dashboard_index, enrollment=enrollment, is_unfulfilled_entitlement=is_unfulfilled_entitlement, is_fulfilled_entitlement=is_fulfilled_entitlement, entitlement=entitlement, entitlement_session=entitlement_session, entitlement_available_sessions=entitlement_available_sessions, entitlement_expiration_date=entitlement_expiration_date, entitlement_expired_at=entitlement_expired_at, show_courseware_link=show_courseware_link, cert_status=cert_status, can_refund_entitlement=can_refund_entitlement, can_unenroll=can_unenroll, credit_status=credit_status, show_email_settings=show_email_settings, course_mode_info=course_mode_info, is_paid_course=is_paid_course, verification_status=course_verification_status, course_requirements=course_requirements, dashboard_index=dashboard_index, share_settings=share_settings, user=user, related_programs=related_programs, display_course_modes_on_dashboard=display_course_modes_on_dashboard, show_consent_link=show_consent_link, enterprise_customer_name=enterprise_customer_name, resume_button_url=resume_button_url, partner_managed_enrollment=partner_managed_enrollment' />
             % endfor
-
+            % if show_load_all_courses_link:
+                <br/>
+                 ${len(course_enrollments)} ${_("results successfully populated,")}
+                 <a href="${reverse('dashboard')}?course_limit=None">
+                     ${_("Click to load all enrolled courses")}
+                </a>
+            % endif
             </ul>
           % else:
             <div class="empty-dashboard-message">
@@ -247,7 +264,7 @@ from student.models import CourseEnrollment
           % endif
         </div>
       </div>
-      <div class="side-container">
+      <div class="side-container" role="complementary" aria-label="messages">
         %if display_sidebar_account_activation_message:
           <div class="sidebar-notification">
             <%include file="${static.get_template_path('registration/account_activation_sidebar_notice.html')}" />
@@ -272,6 +289,15 @@ from student.models import CourseEnrollment
           <div id="dashboard-search-results" class="search-results dashboard-search-results"></div>
         % endif
 
+        <%block name="skip_links">
+          % if settings.FEATURES.get('ENABLE_ANNOUNCEMENTS'):
+            <a id="announcements-skip" class="nav-skip sr-only sr-only-focusable" href="#announcements">${_("Skip to list of announcements")}</a>
+          % endif
+        </%block>
+        % if settings.FEATURES.get('ENABLE_ANNOUNCEMENTS'):
+          <%include file='dashboard/_dashboard_announcements.html' />
+        % endif
+
         % if display_sidebar_on_dashboard:
           <div class="profile-sidebar" id="profile-sidebar" role="region" aria-label="Account Status Info">
             <header class="profile">
@@ -279,15 +305,6 @@ from student.models import CourseEnrollment
             </header>
             <div class="user-info">
               <ul>
-
-                % if len(order_history_list):
-                <li class="order-history">
-                  <span class="title">${_("Order History")}</span>
-                  % for order_history_item in order_history_list:
-                    <span><a href="${order_history_item['receipt_url']}" target="_blank" class="edit-name">${order_history_item['order_date']}</a></span>
-                  % endfor
-                </li>
-                % endif
 
                 <%include file="${static.get_template_path('dashboard/_dashboard_status_verification.html')}" />
 


### PR DESCRIPTION
#### Related issue
https://github.com/mitodl/mitxpro-theme/issues/31

#### Description
With edx's master (koa), mitxpro-theme breaks at /dashboard if the user has any enrolled course.

#### Feasible approaches
There are two approaches to get this issue fixed.
1) Rebasing dashboard with edx's master (koa) dashboard.
2) Pick the variable which causes the issue and add it to the mako template.

I have used the first approach to update the whole dashboard.html, because I think it's better to keep things updated as much as we can.

#### Related issues
https://github.com/mitodl/mitxpro-theme/pull/24/files

#### Screenshots
Before:
![image](https://user-images.githubusercontent.com/42243411/98805519-818a6a80-2439-11eb-810e-8bfc870a8695.png)

After:
![image](https://user-images.githubusercontent.com/42243411/98807069-f068c300-243b-11eb-86bd-1889e8629710.png)
