### PR TITLE
Koa: Override contact us page

### DIFF
--- a/lms/templates/support/contact_us.html
+++ b/lms/templates/support/contact_us.html
@@ -1,0 +1,33 @@
+<%!
+from django.utils.translation import ugettext as _
+%>
+
+<%inherit file="../main.html"/>
+
+<%block name="title">
+    <title>
+        ${_("Contact {platform_name} Support").format(platform_name=platform_name)}
+    </title>
+</%block>
+
+<%block name="head_extra">
+    <link type="text/css" rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.7/css/bootstrap.min.css">
+</%block>
+
+<main id="main" aria-label="Content">
+  <div id="root" class="container">
+    <h2 class="heading-left">${_("Contact Us")}</h2>
+    <p style="padding-top: 16px">
+      Find answers to common questions asked by xPRO learners in the
+      <a href="https://xpro.zendesk.com/hc/">
+        MIT xPRO Help Center.
+      </a>
+    </p>
+    <p>
+      For other support questions, please
+      <a href="https://xpro.zendesk.com/hc/en-us/requests/new">
+        submit your question here.
+      </a>
+    </p>
+  </div>
+</main>


### PR DESCRIPTION
This is a reapplication of PR #34 on the koa branch

Closes #33 

This PR overrides the contact Us page in our xPRO theme.

**Testing Instructions:**
- On your LMS go to `/support/contact_us`
- Verify that you see two links as mentioned in the associated ticket instead of Open edX's default contact Us page.

**Screenshots:**
<img width="953" alt="Screenshot 2020-12-09 at 3 20 12 PM" src="https://user-images.githubusercontent.com/34372316/101626110-4a11dc80-3a3e-11eb-944c-3e622dfcb844.png">
