### PR TITLE
feat(footer): update accessibility link title

### DIFF
--- a/lms/templates/footer.html
+++ b/lms/templates/footer.html
@@ -33,6 +33,9 @@
     elif link['name'] == "honor_code":
         link["url"] = urljoin(settings.MARKETING_SITE_BASE_URL, "honor-code")
         footer["legal_links"][item_num] = link
+    elif link['name'] == "accessibility_policy":
+        link["title"] = "Accessibility"
+        footer["legal_links"][item_num] = link
 
 %>
 <%namespace name='static' file='static_content.html'/>


### PR DESCRIPTION
#### Pre-Flight checklist

- [ ] Testing (Could not test as my edX is configured with the Devstack and I need to figure it out with tutor)
  - [ ] Code is tested
  - [ ] Changes have been manually tested
- [x] Settings
  - [x] New settings have reasonable development defaults, if applicable
  - [x] Opened issue in the [ol-infrastructure repo](https://github.com/mitodl/ol-infrastructure/issues/new) for any necessary configuration changes to deployed environments

#### What are the relevant tickets?
Fixes https://github.com/mitodl/hq/issues/759 & https://github.com/mitodl/hq/issues/631

#### What's this PR do?
Updates the title for the Accessibility link in the footer. The default edX title is `Accessibility Policy` but we require `Accessibility`.

#### How should this be manually tested?

- Follow the readme to integrate the footer.
- Add the following settings in your `private.py`
```
SUPPORT_SITE_LINK = "https://xpro.zendesk.com/hc"
MKTG_URL_LINK_MAP = {
    "ABOUT": "about",
    "PRIVACY": "privacy",
    "TOS": "tos",
    "HONOR": "honor",
    "ACCESSIBILITY": "accessibility_policy",
    "HELP_CENTER": "help-center"
}
MKTG_URL_OVERRIDES = {
        "PRIVACY": "https://rc.xpro.mit.edu/privacy-policy/",
        "TOS": "https://rc.xpro.mit.edu/terms-of-service/",
        "ABOUT": "https://rc.xpro.mit.edu/about-us/",
        "HONOR": "https://rc.xpro.mit.edu/honor-code/",
        "ACCESSIBILITY": "https://accessibility.mit.edu/",
        "TOS_AND_HONOR": ""
    }
```

#### Any background context you want to provide?
Changes are inspired by https://github.com/mitodl/frontend-component-footer-mitol/pull/9#issuecomment-1448501818

We already made these changes for MIT xOnline. I didn't know that we have a separate theme for xPro. Here is the PR for the changes in xOnline. https://github.com/mitodl/mitxonline-theme/pull/32

