### PR TITLE
fix: remove unused Journals and Profile tabs

### DIFF
--- a/lms/templates/header/navbar-authenticated.html
+++ b/lms/templates/header/navbar-authenticated.html
@@ -18,7 +18,7 @@ from openedx.core.djangoapps.site_configuration import helpers as configuration_
     sysadmin_dashboard = show_sysadmin_dashboard(user)
   except:
     sysadmin_dashboard = None
-  
+
   show_explore_courses = settings.FEATURES.get('COURSES_ARE_BROWSABLE') and not show_program_listing
   self.real_user = getattr(user, 'real_user', user)
 
@@ -51,20 +51,6 @@ from openedx.core.djangoapps.site_configuration import helpers as configuration_
           </a>
         </div>
       % endif
-      % if show_journal_listing:
-        <div class="mobile-nav-item hidden-mobile nav-item nav-tab">
-          <a class="${'active ' if reverse('openedx.journals.dashboard') in request.path else ''}tab-nav-link" href="${reverse('openedx.journals.dashboard')}"
-             aria-current="${'page' if reverse('openedx.journals.dashboard') == request.path else 'false'}">
-             ${_("Journals")}
-          </a>
-        </div>
-      % endif
-      <div class="mobile-nav-item hidden-mobile nav-item nav-tab">
-          <a class="${'active ' if '/u/' in request.path  else ''}tab-nav-link" href="${reverse('learner_profile', args=[self.real_user.username])}"
-             aria-current="${'page' if '/u/' in request.path else 'false'}">
-             ${_("Profile")}
-          </a>
-      </div>
     % endif
     % if show_explore_courses:
       <div class="mobile-nav-item hidden-mobile nav-item nav-tab">


### PR DESCRIPTION
#### Associated Ticket:
#45 

#### What this PR does:
- Removed the unused tabs, e.g. `Profile` and `Journals`
- Open edX has removed these from their upstream themes as well so we should remove these too, Removing these would make the theme less breakable with ongoing changes in edX.


#### How should this be tested?

- Should be tested both on `master` and `olive` branch of edX
- Once your edX instance is setup, Follow the instructions in the `readme` of this repo and setup theme on this branch, nothing should break
- A smoke test is good