### PR TITLE
fix: use marketing_link helper instead of MKTG_URLS for CONTACT (#56)

### DIFF
--- a/cms/templates/404.html
+++ b/cms/templates/404.html
@@ -20,7 +20,7 @@ from openedx.core.djangolib.markup import HTML, Text
       ${Text(_('Go back to the {homepage} or contact us about any pages that may have been moved at {contact_us}.')).format(
         homepage=HTML('<a href="{marketing_site_base_url}">homepage</a>').format(marketing_site_base_url=settings.MARKETING_SITE_BASE_URL),
         contact_us=HTML('<a href="{address}">contact us</a>').format(
-          address=Text(settings.MKTG_URLS.get('CONTACT', None))
+          address=Text(marketing_link('CONTACT'))
         )
       )}
       </p>

--- a/lms/templates/footer.html
+++ b/lms/templates/footer.html
@@ -19,7 +19,7 @@
       link_data["title"] = _("Support Center")
       footer["navigation_links"][idx] = link_data
     elif link_data["name"] == "contact":
-      contact_url = settings.MKTG_URLS.get("CONTACT", None)
+      contact_url = marketing_link('CONTACT')
       if contact_url:
         link_data["url"] = contact_url
         footer["navigation_links"][idx] = link_data

--- a/lms/templates/static_templates/404.html
+++ b/lms/templates/static_templates/404.html
@@ -22,7 +22,7 @@ from openedx.core.djangolib.markup import HTML, Text
                 ${Text(_('Go back to the {homepage} or contact us about any pages that may have been moved at {email}.')).format(
                   homepage=HTML('<a href="{marketing_site_base_url}">homepage</a>').format(marketing_site_base_url=settings.MARKETING_SITE_BASE_URL),
                   email=HTML('<a href="{address}">contact us</a>').format(
-                    address=Text(settings.MKTG_URLS.get('CONTACT', None))
+                    address=Text(marketing_link('CONTACT'))
                   )
                 )}
                 % endif


### PR DESCRIPTION
# What are the relevant tickets?

backport of https://github.com/mitodl/mitxpro-theme/pull/56 for the `Quince` branch.
