### PR TITLE
style: shift back to use logo from production

### DIFF
--- a/lms/templates/ace_common/edx_ace/common/base_body.html
+++ b/lms/templates/ace_common/edx_ace/common/base_body.html
@@ -62,7 +62,7 @@
                     <tr>
                         <td width="70">
                             <a href="{% with_link_tracking homepage_url %}"><img
-                                    src="https://courses-rc.xpro.mit.edu/static/mitxpro-theme/images/logo.svg" width="125"
+                                    src="https://courses.xpro.mit.edu/static/mitxpro-theme/images/logo.png" width="125"
                                     height="35" alt="{% filter force_escape %}{% blocktrans %}Go to {{ platform_name }} Home Page{% endblocktrans %}{% endfilter %}"/></a>
                         </td>
                         <td align="right" style="text-align: {{ LANGUAGE_BIDI|yesno:"left,right" }};">


### PR DESCRIPTION
### What are the relevant tickets?
None

### Description (What does it do?)
When we migrated towards using the new logo in xPRO we added the rc logo in the email for testing. But we are using the email template from Django admin so we can change the logo URL from there whenever we need to. So, I'm doing two things in this PR
- Change the default logo to be a PNG instead of SVG because email doesn't support SVG logo
- Change the RC URL to production URL
