### PR TITLE
fix: remove maintenance:maintenance_index from the user_dropdown.

### DIFF
--- a/cms/templates/widgets/user_dropdown.html
+++ b/cms/templates/widgets/user_dropdown.html
@@ -51,11 +51,6 @@ full_name = UserProfile.objects.get(user=user).name
         <li class="nav-item nav-account-dashboard">
           <a href="/">${_("{studio_name} Home").format(studio_name=settings.STUDIO_SHORT_NAME)}</a>
         </li>
-        % if GlobalStaff().has_user(user):
-        <li class="nav-item">
-          <a href="${reverse('maintenance:maintenance_index')}">${_("Maintenance")}</a>
-        </li>
-        % endif
         <li class="nav-item nav-account-signout">
           <a class="action action-signout" href="${settings.FRONTEND_LOGOUT_URL}">${_("Sign Out")}</a>
         </li>


### PR DESCRIPTION
~ Copilot PR ~

### What are the relevant tickets?
Closes https://github.com/mitodl/hq/issues/9265

### Description (What does it do?)
- Problem: The theme template tried to reverse a URL for a maintenance feature that doesn't exist in the standard Ulmo release
- Solution: Removed the maintenance menu item (lines 54-58) from the CMS user dropdown template
- Impact: The user dropdown will now only show "Studio Home" and "Sign Out" options, which are standard features available in all edx-platform releases
